### PR TITLE
Tweaks from Prettier, etc.

### DIFF
--- a/.cracorc.js
+++ b/.cracorc.js
@@ -1,4 +1,3 @@
-// CRACO must use `module.exports = ...`  over `export default ...`
 module.exports = {
   babel: {
     loaderOptions: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ['react-app', 'prettier'],
+  plugins: ['prettier'],
+  rules: {
+    'prettier/prettier': 'error',
+  },
+}

--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-
-
 # Created by https://www.toptal.com/developers/gitignore/api/react,node,linux,macos,windows,git,firebase,storybookjs
 # Edit at https://www.toptal.com/developers/gitignore?templates=react,node,linux,macos,windows,git,firebase,storybookjs
 
@@ -76,7 +74,6 @@ yarn-error.log*
 
 # Icon must end with two \r
 Icon
-
 
 # Thumbnails
 ._*

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  semi: false,
+  singleQuote: true,
+  tabWidth: 2,
+  trailingComma: 'all',
+}

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,11 +1,8 @@
-module.exports = {
-  "stories": [
-    "../src/**/*.stories.mdx",
-    "../src/**/*.stories.@(js|jsx|ts|tsx)"
+export default {
+  stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  addons: [
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/preset-create-react-app',
   ],
-  "addons": [
-    "@storybook/addon-links",
-    "@storybook/addon-essentials",
-    "@storybook/preset-create-react-app"
-  ]
 }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,5 @@
 export const parameters = {
-  actions: { argTypesRegex: "^on[A-Z].*" },
+  actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {
     matchers: {
       color: /(background|color)$/i,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,5 @@
 # Focus on React component design
+
 - All components must be within their own folder (1 folder per component).
   - A subcomponent is permitted to be within a subfolder of a component folder if it is not used in any other component.
 - Each component should have a working storyboard file.
@@ -6,6 +7,7 @@
 - Each component should link to a CSS file (even if there are no styles in it).
 
 # Maintain an organized directory structure
+
 - The `src/` folder must have a few subfolders to categorize components and other code:
   - pages
   - components
@@ -13,6 +15,7 @@
   - models (for parsing GPS data / GPX and consuming them)
 
 # Pull Requests are required to merge to `master`
+
 - Pull Requests to `master` must have at least reviewer before it can be accepted.
 - Pull Requests to `master` must check that all tests are passing before it can be accepted.
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,33 @@
 # Async Racing
+
 <!-- Add description of app here. -->
 
 ## Dev Setup
+
 <!-- Introduce the step-by-step guide to set up and contribute to the project. -->
 
 ## Tech Stack
-| Technology        | Usage     |
-|:------------------|:----------|
+
+| Technology        | Usage                                |
+| :---------------- | :----------------------------------- |
 | GitHub            | Version Control; Collaboration Tools |
-| TypeScript        | Frontend  |
-| JavaScript ESNext | Frontend  |
-| React.js          | Frontend  |
-| Jest              | Testing   |
-| Firebase          | Database  |
-| Google Analytics  | Analytics |
-| Netlify           | Hosting; Continuous Integration |
-| MapBox            | Map API   |
+| TypeScript        | Frontend                             |
+| JavaScript ESNext | Frontend                             |
+| React.js          | Frontend                             |
+| Jest              | Testing                              |
+| Firebase          | Database                             |
+| Google Analytics  | Analytics                            |
+| Netlify           | Hosting; Continuous Integration      |
+| MapBox            | Map API                              |
 
 # Contributors
+
 - [Ben Simpson]
 - [Ian Rones]
 - [Nolan Kovacik]
 - [Thomas Sarlandie]
 
-[Ben Simpson]: #
-[Ian Rones]: #
-[Nolan Kovacik]: https://github.com/noltron000
-[Thomas Sarlandie]: #
+[ben simpson]: #
+[ian rones]: #
+[nolan kovacik]: https://github.com/noltron000
+[thomas sarlandie]: #

--- a/craco.config.js
+++ b/craco.config.js
@@ -1,3 +1,4 @@
+// CRACO must use `module.exports = ...`  over `export default ...`
 module.exports = {
   babel: {
     loaderOptions: {

--- a/package.json
+++ b/package.json
@@ -62,23 +62,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "prettier"
-    ],
-    "plugins": [
-      "prettier"
-    ],
-    "rules": {
-      "prettier/prettier": "error"
-    }
-  },
-  "prettier": {
-    "semi": false,
-    "singleQuote": true,
-    "tabWidth": 2,
-    "trailingComma": "all"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,12 +63,6 @@
       "last 1 safari version"
     ]
   },
-  "prettier": {
-    "semi": false,
-    "singleQuote": true,
-    "tabWidth": 2,
-    "trailingComma": "all"
-  },
   "eslintConfig": {
     "extends": [
       "react-app",
@@ -80,5 +74,11 @@
     "rules": {
       "prettier/prettier": "error"
     }
+  },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true,
+    "tabWidth": 2,
+    "trailingComma": "all"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -2,37 +2,22 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link
-      rel="icon"
-      href="%PUBLIC_URL%/favicon.ico"
-    />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
 
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1"
-    />
-    <meta
-      name="theme-color"
-      content="#000000"
-    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
     <meta
       name="description"
       content="Web site created using create-react-app"
     />
 
-    <link
-      rel="apple-touch-icon"
-      href="%PUBLIC_URL%/logo192.png"
-    />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
 
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link
-      rel="manifest"
-      href="%PUBLIC_URL%/manifest.json"
-    />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
@@ -45,8 +30,8 @@
 
     <!-- Use the MapBox API's special style sheet -->
     <link
-      href='https://api.tiles.mapbox.com/mapbox-gl-js/v2.3.1/mapbox-gl.css'
-      rel='stylesheet'
+      href="https://api.tiles.mapbox.com/mapbox-gl-js/v2.3.1/mapbox-gl.css"
+      rel="stylesheet"
     />
 
     <title>React App</title>

--- a/src/deckgl.d.ts
+++ b/src/deckgl.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
-import * as DeckTypings from '@danmarshall/deckgl-typings';
+import * as DeckTypings from '@danmarshall/deckgl-typings'
 
 declare module 'deck.gl' {
-    export namespace DeckTypings {}
+  export namespace DeckTypings {}
 }

--- a/src/pages/StorybookIntro/StorybookIntro.stories.mdx
+++ b/src/pages/StorybookIntro/StorybookIntro.stories.mdx
@@ -1,12 +1,12 @@
-import { Meta } from '@storybook/addon-docs';
-import Code from '../../assets/code-brackets.svg';
-import Colors from '../../assets/colors.svg';
-import Comments from '../../assets/comments.svg';
-import Direction from '../../assets/direction.svg';
-import Flow from '../../assets/flow.svg';
-import Plugin from '../../assets/plugin.svg';
-import Repo from '../../assets/repo.svg';
-import StackAlt from '../../assets/stackalt.svg';
+import { Meta } from '@storybook/addon-docs'
+import Code from '../../assets/code-brackets.svg'
+import Colors from '../../assets/colors.svg'
+import Comments from '../../assets/comments.svg'
+import Direction from '../../assets/direction.svg'
+import Flow from '../../assets/flow.svg'
+import Plugin from '../../assets/plugin.svg'
+import Repo from '../../assets/repo.svg'
+import StackAlt from '../../assets/stackalt.svg'
 
 <Meta title="Example/Storyboard Intro" />
 
@@ -180,14 +180,22 @@ We recommend building UIs with a [**component-driven**](https://componentdriven.
       Configure, customize, and extend
     </span>
   </a>
-  <a className="link-item" href="https://storybook.js.org/tutorials/" target="_blank">
+  <a
+    className="link-item"
+    href="https://storybook.js.org/tutorials/"
+    target="_blank"
+  >
     <img src={Direction} alt="direction" />
     <span>
       <strong>In-depth guides</strong>
       Best practices from leading teams
     </span>
   </a>
-  <a className="link-item" href="https://github.com/storybookjs/storybook" target="_blank">
+  <a
+    className="link-item"
+    href="https://github.com/storybookjs/storybook"
+    target="_blank"
+  >
     <img src={Code} alt="code" />
     <span>
       <strong>GitHub project</strong>


### PR DESCRIPTION
### Non-essential PR

1. I ran prettier on every file that it could parse.
1. I'd rather have ALL library configs in `package.json`, or NONE (each have their own file). It doesn't matter to me. I chose the later style and split the three configs into their own files.

*\*<kbd>CRACO</kbd> made this decision easy: their config cannot exist in `package.json`. It must exist in its own file.*