### PR TITLE
Fixing storybook config

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
     '@storybook/addon-links',

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,4 @@
-export const parameters = {
+module.exports.parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {
     matchers: {


### PR DESCRIPTION
ES6 exports don't work with the storybook config, or other configs.

This quick fix will undo the issue.