### PR TITLE
Update types

### DIFF
--- a/src/components/Course/ChallengeCourse.tsx
+++ b/src/components/Course/ChallengeCourse.tsx
@@ -62,17 +62,14 @@ const Pin = ({ point, setPoint }: PinProps) => {
 
 // helper component
 const Waypoint = ({ line, setLine }: WaypointProps) => {
-  // Deconstruct the given GPSLine.
-  const { firstPoint, secondPoint } = line
-
   // This function must be updated with our line points every time it changes.
   const redraw = ({ project }: { project: any }) => {
     // The `project()` function is sort of a "magic" function that ReactMapGL
     //   passes in as a parameter to the redraw function.
     // Given an input of lon/lat coords on the globe,
     //   it converts it to HTML-readable X/Y coords on the page.
-    const [x1, y1] = project([firstPoint.lon, firstPoint.lat])
-    const [x2, y2] = project([secondPoint.lon, secondPoint.lat])
+    const [x1, y1] = project([line[0].lon, line[0].lat])
+    const [x2, y2] = project([line[1].lon, line[1].lat])
 
     // The app expects redraw to return SVG-compatible JSX elements.
     return (
@@ -80,16 +77,20 @@ const Waypoint = ({ line, setLine }: WaypointProps) => {
     )
   }
 
-  const getSetPointOf = useCallback(
-    (name: string) => (point: GPSPoint) => setLine({ ...line, [name]: point }),
+  const getSetPointAt = useCallback(
+    (index: number) => (point: GPSPoint) => {
+      const newLine = [...line]
+      newLine[index] = point
+      return setLine(newLine)
+    },
     [line, setLine],
   )
 
   return (
     <>
       <SVGOverlay redraw={redraw} style={{ 'pointer-events': 'none' }} />
-      <Pin point={line.firstPoint} setPoint={getSetPointOf('firstPoint')} />
-      <Pin point={line.secondPoint} setPoint={getSetPointOf('secondPoint')} />
+      <Pin point={line[0]} setPoint={getSetPointAt(0)} />
+      <Pin point={line[1]} setPoint={getSetPointAt(1)} />
     </>
   )
 }

--- a/src/components/Course/ChallengeCourse.tsx
+++ b/src/components/Course/ChallengeCourse.tsx
@@ -35,8 +35,8 @@ const Pin = ({ point, setPoint }: PinProps) => {
   const onDrag = useCallback(
     (event: any) => {
       setPoint({
-        lon: event.lngLat[0],
-        lat: event.lngLat[1],
+        longitude: event.lngLat[0],
+        latitude: event.lngLat[1],
       })
     },
     [setPoint],
@@ -44,8 +44,8 @@ const Pin = ({ point, setPoint }: PinProps) => {
 
   return (
     <Marker
-      longitude={point.lon}
-      latitude={point.lat}
+      longitude={point.longitude}
+      latitude={point.latitude}
       offsetTop={-50}
       offsetLeft={-25}
       draggable
@@ -68,8 +68,8 @@ const Waypoint = ({ line, setLine }: WaypointProps) => {
     //   passes in as a parameter to the redraw function.
     // Given an input of lon/lat coords on the globe,
     //   it converts it to HTML-readable X/Y coords on the page.
-    const [x1, y1] = project([line[0].lon, line[0].lat])
-    const [x2, y2] = project([line[1].lon, line[1].lat])
+    const [x1, y1] = project([line[0].longitude, line[0].latitude])
+    const [x2, y2] = project([line[1].longitude, line[1].latitude])
 
     // The app expects redraw to return SVG-compatible JSX elements.
     return (

--- a/src/components/GetMapTrack/GetMapTrack.tsx
+++ b/src/components/GetMapTrack/GetMapTrack.tsx
@@ -12,26 +12,26 @@ import { Challenge, Track, TrackPath } from '../../model/ChallengeConfiguration'
 /* helpers & constants */
 // This will initialize a challenge from a couple of lines.
 const defaultChallenge: Challenge = {
-  start: {
-    firstPoint: {
+  start: [
+    {
       lon: -122.4,
       lat: 37.7,
     },
-    secondPoint: {
+    {
       lon: -122.4,
       lat: 37.8,
     },
-  },
-  finish: {
-    firstPoint: {
+  ],
+  finish: [
+    {
       lon: -122.5,
       lat: 37.7,
     },
-    secondPoint: {
+    {
       lon: -122.5,
       lat: 37.8,
     },
-  },
+  ],
 }
 
 /* react components */

--- a/src/components/GetMapTrack/GetMapTrack.tsx
+++ b/src/components/GetMapTrack/GetMapTrack.tsx
@@ -14,22 +14,22 @@ import { Challenge, Track, TrackPath } from '../../model/ChallengeConfiguration'
 const defaultChallenge: Challenge = {
   start: [
     {
-      lon: -122.4,
-      lat: 37.7,
+      longitude: -122.4,
+      latitude: 37.7,
     },
     {
-      lon: -122.4,
-      lat: 37.8,
+      longitude: -122.4,
+      latitude: 37.8,
     },
   ],
   finish: [
     {
-      lon: -122.5,
-      lat: 37.7,
+      longitude: -122.5,
+      latitude: 37.7,
     },
     {
-      lon: -122.5,
-      lat: 37.8,
+      longitude: -122.5,
+      latitude: 37.8,
     },
   ],
 }

--- a/src/components/Map/ChallengeMap.stories.tsx
+++ b/src/components/Map/ChallengeMap.stories.tsx
@@ -22,13 +22,13 @@ OneRedTrack.args = {
     {
       path: [
         {
-          lon: -122.49005,
-          lat: 37.68493,
+          longitude: -122.49005,
+          latitude: 37.68493,
           time: new Date(),
         },
         {
-          lon: -122.41737904607598,
-          lat: 37.7866555224718,
+          longitude: -122.41737904607598,
+          latitude: 37.7866555224718,
           time: new Date(),
         },
       ],
@@ -44,13 +44,13 @@ TwoTracks.args = {
     {
       path: [
         {
-          lon: -122.49005,
-          lat: 37.68493,
+          longitude: -122.49005,
+          latitude: 37.68493,
           time: new Date(),
         },
         {
-          lon: -122.41737904607598,
-          lat: 37.7866555224718,
+          longitude: -122.41737904607598,
+          latitude: 37.7866555224718,
           time: new Date(),
         },
       ],
@@ -60,13 +60,13 @@ TwoTracks.args = {
     {
       path: [
         {
-          lon: -122.490569,
-          lat: 37.684839,
+          longitude: -122.490569,
+          latitude: 37.684839,
           time: new Date(),
         },
         {
-          lon: -122.490562,
-          lat: 37.68481,
+          longitude: -122.490562,
+          latitude: 37.68481,
           time: new Date(),
         },
       ],

--- a/src/components/Map/ChallengeMap.tsx
+++ b/src/components/Map/ChallengeMap.tsx
@@ -67,7 +67,7 @@ const ChallengeMap = ({ tracks, challenge, setChallenge }: PropTypes) => {
       data: tracks,
       pickable: true,
       widthMinPixels: 2,
-      getPath: (d) => d.path.map((point) => [point.lon, point.lat]),
+      getPath: (d) => d.path.map((point) => [point.longitude, point.latitude]),
       getColor: (d) => d.color,
       getWidth: () => 5,
     }),

--- a/src/examples/test-data.ts
+++ b/src/examples/test-data.ts
@@ -1,26 +1,26 @@
 import { Challenge } from '../model/ChallengeConfiguration'
 
 const testData: Challenge = {
-  start: {
-    firstPoint: {
+  start: [
+    {
       lat: -122.45,
       lon: -122.45,
     },
-    secondPoint: {
+    {
       lat: 34.956,
       lon: -120.32,
     },
-  },
-  finish: {
-    firstPoint: {
+  ],
+  finish: [
+    {
       lat: 19.3,
       lon: -120,
     },
-    secondPoint: {
+    {
       lat: 30.299,
       lon: -100.4932,
     },
-  },
+  ],
 }
 
 export { testData }

--- a/src/examples/test-data.ts
+++ b/src/examples/test-data.ts
@@ -3,22 +3,22 @@ import { Challenge } from '../model/ChallengeConfiguration'
 const testData: Challenge = {
   start: [
     {
-      lat: -122.45,
-      lon: -122.45,
+      latitude: -122.45,
+      longitude: -122.45,
     },
     {
-      lat: 34.956,
-      lon: -120.32,
+      latitude: 34.956,
+      longitude: -120.32,
     },
   ],
   finish: [
     {
-      lat: 19.3,
-      lon: -120,
+      latitude: 19.3,
+      longitude: -120,
     },
     {
-      lat: 30.299,
-      lon: -100.4932,
+      latitude: 30.299,
+      longitude: -100.4932,
     },
   ],
 }

--- a/src/model/ChallengeConfiguration.ts
+++ b/src/model/ChallengeConfiguration.ts
@@ -18,10 +18,7 @@ interface Track {
 }
 
 // For start & finish lines, plus waypoints
-interface GPSLine {
-  firstPoint: GPSPoint
-  secondPoint: GPSPoint
-}
+type GPSLine = [GPSPoint, GPSPoint]
 
 // The configuration for a race or challenge
 interface Challenge {

--- a/src/model/ChallengeConfiguration.ts
+++ b/src/model/ChallengeConfiguration.ts
@@ -1,6 +1,6 @@
 interface GPSPoint {
-  lat: number // latitude
-  lon: number // longitude
+  latitude: number // 90° > latitude > -90°
+  longitude: number // 180° > longitude > -180°
 }
 
 interface TrackPoint extends GPSPoint {

--- a/src/model/track-bounds.ts
+++ b/src/model/track-bounds.ts
@@ -5,40 +5,46 @@ export const trackBounds = (
 ): [northEastCorner: [number, number], southWestCorner: [number, number]] => {
   if (path.length > 0) {
     const eastPoint = path.reduce((accumulator, currentPoint) => {
-      const currentValue = currentPoint.lat
-      const accumulatorValue = accumulator.lat
+      const currentValue = currentPoint.latitude
+      const accumulatorValue = accumulator.latitude
       if (accumulatorValue > currentValue) {
         return accumulator
       }
       return currentPoint
     })
     const westPoint = path.reduce((accumulator, currentPoint) => {
-      const currentValue = currentPoint.lat
-      const accumulatorValue = accumulator.lat
+      const currentValue = currentPoint.latitude
+      const accumulatorValue = accumulator.latitude
       if (accumulatorValue < currentValue) {
         return accumulator
       }
       return currentPoint
     })
     const northPoint = path.reduce((accumulator, currentPoint) => {
-      const currentValue = currentPoint.lon
-      const accumulatorValue = accumulator.lon
+      const currentValue = currentPoint.longitude
+      const accumulatorValue = accumulator.longitude
       if (accumulatorValue > currentValue) {
         return accumulator
       }
       return currentPoint
     })
     const southPoint = path.reduce((accumulator, currentPoint) => {
-      const currentValue = currentPoint.lon
-      const accumulatorValue = accumulator.lon
+      const currentValue = currentPoint.longitude
+      const accumulatorValue = accumulator.longitude
       if (accumulatorValue < currentValue) {
         return accumulator
       }
       return currentPoint
     })
 
-    const northEastCorner = [northPoint.lon, eastPoint.lat] as [number, number]
-    const southWestCorner = [southPoint.lon, westPoint.lat] as [number, number]
+    const northEastCorner = [northPoint.longitude, eastPoint.latitude] as [
+      number,
+      number,
+    ]
+    const southWestCorner = [southPoint.longitude, westPoint.latitude] as [
+      number,
+      number,
+    ]
 
     return [northEastCorner, southWestCorner]
   }

--- a/src/model/useTextToPath.ts
+++ b/src/model/useTextToPath.ts
@@ -9,8 +9,8 @@ const parseGpxText = (textData: string): Array<TrackPath> => {
   gpx.parse(textData)
   return gpx.tracks.map((track) =>
     track.points.map((point) => ({
-      lat: point.lat,
-      lon: point.lon,
+      latitude: point.lat,
+      longitude: point.lon,
       time: point.time,
     })),
   )


### PR DESCRIPTION
This PR is made to make types more coherent. 

#### Latitude / Longitude
Arguably, shorthands for single-word variables get confusing, especially when combining two or more libraries that make use of different naming conventions. Some libraries use `lat` and `lon`, others use arrays (`event.latLon`), others still use the whole variable `latitude` and `longitude` for their data.

I think its best if we just keep it simple by using full words within our project.

---

#### Arrays for lines
I've found that a tuple of two points are more coherent for the Start line and Finish line than listing out an object that essentially says "first point" and "second point". Therefore, I'm converting the object typing to a tuple typing.